### PR TITLE
speaker page: +deadline, compensation msg; +pycharm path to .gitignor…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+*.idea/
 
 # Lektor
 */assets/static/*

--- a/PyBay/content/speaking/contents.lr
+++ b/PyBay/content/speaking/contents.lr
@@ -6,26 +6,32 @@ short: Speaking
 ---
 body:
 
-Applying to give a conference talk is a big deal. Firstly, we would like to thank you for your effort in submitting your talk. We can't put on a conference without speakers and your knowledge is what inspires the audience to try new things.
+Applying to give a conference talk is a big deal. First, we thank you for your effort in submitting your talk. We can't put on a conference without great speakers and your knowledge is what inspires the audience to try new things.
 
 We want you to be able to give a great talk whether it is your first time or you are an experienced veteran.
 
 Here's the deal:
+- DEADLINE for talk submissions is 31 July - earlier submittals are more likely to be accepted
 - If we select your talk,
-  - you will
+  - you will:
    - show up at the conference venue at least 3 hours before your talk spot otherwise we will cancel your speaking spot
    - be practiced and prepared to speak
-  - we will
-   - offer you a discount code for 2 friends @ 1/3 off ticket prices, we want you to bring your moral support
+   - use your platform LinkedIn, Mastodon, etc to promote the conference and your talk
+  - we will:
+   - offer you a free ticket for yourself, plus one free conference t-shirt
+   - offer you a discount code for 2 friends @ 1/3 off ticket prices (we want you to bring your moral support!)
    - work with you to help you put your best forward
    - respond to your concerns
     - we might not be able to help but we promise to listen
 - If we don't select your talk,
- - we will
+ - we will:
    - offer you a discount code for 1/3 off your ticket price
- - what we hope from you in return
+ - what we hope from you in return:
    - use your platform LinkedIn, Mastodon, etc to promote the conference and your talk
    - submit again next year
+- Speaker compensation is limited
+   - we are able able to offer the items listed above, but are a nonprofit with limited resources
+   - though PyBay is actively soliciting sponsors we are currently unable to offer either direct monetary compensation or commit to blanket reimbursement of travel expenses.  Most past speakers who travelled from outside the San Francisco Bay Area had their companies sponsor travel.
 
 Deal?
 


### PR DESCRIPTION
+ edits to speaker page for deadline (which is only on sessionize) & speaker compensation
+ .gitignore flag to hide pycharm files

We just launched our first PyBay 2024 marketing email today, and already got a question about deadline and speaker comp.