### PR TITLE
Fix- Logo distortion on Safari and mobile and Redirection to sponsor-us

### DIFF
--- a/PyBay/content/sponsors/contents.lr
+++ b/PyBay/content/sponsors/contents.lr
@@ -2,7 +2,7 @@ _model: redirect
 ---
 title: Sponsors
 ---
-target: ../sponsors/our-sponsors/
+target: ../sponsors/sponsor-us/
 ---
 short: Sponsors
 ---

--- a/PyBay/webpack/scss/main.scss
+++ b/PyBay/webpack/scss/main.scss
@@ -1059,7 +1059,7 @@ iframe[src*="player.vimeo.com"]{
   padding: 0px; /* firefox bug fix */
 }
 .navbar-brand>img {
-  height: 100%;
+  height: auto; /* height: 100% was causing logo image distortion on Safari and mobile devices */
   padding: 15px; /* firefox bug fix */
   width: auto;
   max-width: 240px;


### PR DESCRIPTION
**1. Modified the height: 100% to height:auto in main.css**
<img width="1324" alt="Screenshot 2025-05-17 at 21 10 59" src="https://github.com/user-attachments/assets/3c675fbc-d31b-4081-abca-91dc7bdfafd4" />
<img width="935" alt="Screenshot 2025-05-17 at 21 11 33" src="https://github.com/user-attachments/assets/86a871f8-b2ff-4b4c-b51e-0ff19a615081" />

**2. Fixed redirection from /sponsors to /sponsors/sponsor-us**
It was incorrectly redirecting to /sponsors/our-sponsors. This page does not exist. Corrected the redirection.
