### PR TITLE
Removed early bird ticket countdown from home page and speakers page

### DIFF
--- a/PyBay/content/contents.lr
+++ b/PyBay/content/contents.lr
@@ -35,10 +35,6 @@ text:
 </div>
 ----
 class: centered
-#### countdown-timer ####
-countdown_date: 2025-06-30 23:59:59
-----
-countdown_text: Early Bird Tickets On Sale Now Through
 #### text-block ####
 text:
 

--- a/PyBay/content/speaking/current-speakers/contents.lr
+++ b/PyBay/content/speaking/current-speakers/contents.lr
@@ -7,9 +7,6 @@ body:
 <div class="text-center">
 <script type="text/javascript" src="https://sessionize.com/api/v2/3jihguik/view/SpeakerWall"></script>
 
-<h4>Early Bird Tickets On Sale Through June 30, 2025 Midnight PDT</h2>
-<countdown-timer date="2025-07-01T00:00:00-07:00"></countdown-timer>
-
 <br>
 <a class="btn btn-secondary btn-lg" target="_blank" href="https://pretix.eu/bapya/pybay-2025/">Buy Tickets!</a>
 </div>


### PR DESCRIPTION
- Removed the countdown timer block from home page.
- Removed the countdown text from speakers page.