### PR TITLE
A11y improvements to sponsors page

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install and build frontend assets
+        run: |
+          npm ci --prefix PyBay/webpack
+          npm run build --prefix PyBay/webpack
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install and build frontend assets
+      - name: Build assets with webpack
         run: |
           npm ci --prefix PyBay/webpack
-          npm run build --prefix PyBay/webpack
+          npx --yes webpack --config PyBay/webpack/webpack.config.js --mode=production
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,9 +20,10 @@ jobs:
           node-version: '20'
 
       - name: Build assets with webpack
+        working-directory: PyBay/webpack
         run: |
-          npm ci --prefix PyBay/webpack
-          npx --yes webpack --config PyBay/webpack/webpack.config.js --mode=production
+          npm ci
+          npx webpack --config webpack.config.js --mode=production
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,21 @@ jobs:
           python -m playwright install --with-deps chromium
 
       - name: Run E2E a11y tests against built pages
+        id: e2e
         env:
           PLAYWRIGHT_HEADLESS: "1"
+          PYTEST_PLAYWRIGHT_OUTPUT_DIR: test-results
         run: |
-          pytest tests/test_server.py --maxfail=1 --disable-warnings
+          # Retain artifacts on failure so we can upload them
+          pytest tests/test_server.py \
+            --maxfail=1 --disable-warnings \
+            --tracing=retain-on-failure \
+            --screenshot=only-on-failure
+
+      - name: Upload Playwright artifacts
+        if: ${{ failure() && steps.e2e.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            test-results

--- a/PyBay/templates/layout.html
+++ b/PyBay/templates/layout.html
@@ -31,11 +31,11 @@
       src="https://www.facebook.com/tr?id=1184253206099221&ev=PageView&noscript=1" /></noscript>
   <!-- End Meta Pixel Code -->
   <meta charset="utf-8">
-  <link rel="stylesheet" href="{{
-  '/static/gen/styles.css'|asseturl }}">
+  <!-- Bootstrap 5.3.3 CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
-<!-- Bootstrap 5.3.3 CSS -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <!-- Load site styles AFTER Bootstrap so our overrides take effect -->
+  <link rel="stylesheet" href="{{ '/static/gen/styles.css'|asseturl }}">
 
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.2/css/fontawesome.min.css"
@@ -294,6 +294,19 @@ footer a:hover,
 footer a:focus {
   color: #ffefb0 !important;
 }
+
+    /* A11y: ensure sponsor links have sufficient contrast on light grey sections */
+    .sl-group .subscribe-2 a,
+    .sl-group .subscribe-2 .sl-blurb a,
+    .sponsor-list-page .sl-blurb a {
+      color: #0a58ca !important; /* contrast > 4.5 on #f5f5f5 */
+    }
+    .sl-group .subscribe-2 a:hover,
+    .sl-group .subscribe-2 a:focus,
+    .sponsor-list-page .sl-blurb a:hover,
+    .sponsor-list-page .sl-blurb a:focus {
+      color: #084298 !important; /* darker on interaction, maintains contrast */
+    }
 
   </style>
 </head>

--- a/PyBay/templates/layout.html
+++ b/PyBay/templates/layout.html
@@ -295,19 +295,6 @@ footer a:focus {
   color: #ffefb0 !important;
 }
 
-    /* A11y: ensure sponsor links have sufficient contrast on light grey sections */
-    .sl-group .subscribe-2 a,
-    .sl-group .subscribe-2 .sl-blurb a,
-    .sponsor-list-page .sl-blurb a {
-      color: #0a58ca !important; /* contrast > 4.5 on #f5f5f5 */
-    }
-    .sl-group .subscribe-2 a:hover,
-    .sl-group .subscribe-2 a:focus,
-    .sponsor-list-page .sl-blurb a:hover,
-    .sponsor-list-page .sl-blurb a:focus {
-      color: #084298 !important; /* darker on interaction, maintains contrast */
-    }
-
   </style>
 </head>
 

--- a/PyBay/webpack/scss/main.scss
+++ b/PyBay/webpack/scss/main.scss
@@ -1014,7 +1014,7 @@ button.js-gitter-toggle-chat-button {
 
 }
 .sl-blurb a:hover {
-  color: #E0AA8F; /* Your desired hover color */
+  text-decoration-thickness: 2px;
 }
 
 @media(max-width: 1000px) {


### PR DESCRIPTION
This PR improves the accessibility of the sponsors page. Two main changes:

1) Moved site CSS after bootstrap. That's typically what I do when working with Bootstrap, since CSS specificity rules takes into account rules ordering. Easier to override when the site CSS is loaded after.

2) Changed the light orange color of the hover state to a thicker underline instead. I spent a while searching around to see best practices for what to change on hover, but there isn't a consensus. This seems sufficient - the most important thing for links is that the :hover state has a focus outline and the links are clearly visible as links (i.e. they have underlines).

The first link in below screenshot is in hover state:
<img width="580" height="482" alt="Screenshot 2025-08-19 at 10 01 39 PM" src="https://github.com/user-attachments/assets/09361ab6-f71b-4533-802e-d952b71a69b3" />
